### PR TITLE
Bump golang to 1.22.2 and ignore `k8s.io/*` deps by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,29 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+    reviewers:
+      - "ironcore-dev/core"
+    # Ignore K8 packages as these are done manually
+    ignore:
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apiextensions-apiserver"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/apiserver"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/component-base"
+      - dependency-name: "k8s.io/kube-aggregator"
+      - dependency-name: "k8s.io/kubectl"
+      - dependency-name: "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+    reviewers:
+      - "ironcore-dev/core"
   - package-ecosystem: "docker"
     directory: "/docs"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
+    reviewers:
+      - "ironcore-dev/core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
     reviewers:
       - "ironcore-dev/core"
   - package-ecosystem: "docker"
-    directory: "/docs"
+    directory: "/"
     schedule:
       interval: "weekly"
     reviewers:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.55.2
+          version: v1.57.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request_target:
     types: [ opened, reopened, synchronize ]
+  workflow_dispatch:
 
 jobs:
   update_release_draft:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,7 +1,7 @@
 name: Size Label
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 # Build the kubectl-ironcore binary
-FROM golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.13.0
-GOLANGCI_LINT_VERSION ?= v1.55.2
+GOIMPORTS_VERSION ?= v0.20.0
+GOLANGCI_LINT_VERSION ?= v1.57.2
 
 .PHONY: addlicense
 addlicense: $(ADDLICENSE) ## Download addlicense locally if necessary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ironcore-dev/kubectl-ironcore
 
-go 1.21
+go 1.22.2
 
 require (
 	github.com/go-logr/zapr v1.3.0
@@ -14,11 +14,6 @@ require (
 	k8s.io/cluster-bootstrap v0.29.4
 	k8s.io/kubectl v0.29.4
 	sigs.k8s.io/controller-runtime v0.17.3
-)
-
-require (
-	github.com/google/gnostic-models v0.6.8 // indirect
-	golang.org/x/sync v0.5.0 // indirect
 )
 
 require (
@@ -38,6 +33,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
+	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.3.1 // indirect
@@ -67,6 +63,7 @@ require (
 	go4.org/netipx v0.0.0-20220812043211-3cc044ffd68d // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect


### PR DESCRIPTION
# Proposed Changes

- Bump golang 1.22.2
- Bump `goimports` to 0.20.0
- Bump `golangci-lint` to 1.57.2
- Ignore `k8s.io/*` in dependabot configuration