### PR TITLE
Set GKV on Secret before sending it to kube-api

### DIFF
--- a/utils/bootstraptoken/bootstraptoken.go
+++ b/utils/bootstraptoken/bootstraptoken.go
@@ -148,6 +148,10 @@ func ToSecret(token *BootstrapToken) *corev1.Secret {
 	}
 
 	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceSystem,
 			Name:      util.BootstrapTokenSecretName(token.ID),


### PR DESCRIPTION
The current implementation does not set the TypeMeta on the Secret causing the API server to reject the apply.

This commit adds the necessary TypeMeta.